### PR TITLE
Don't call poetry inside the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: # show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9 _-]+:.*#'  Makefile | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
 
 local: # run app in local environment
-	poetry run streamlit run app.py
+	streamlit run app.py
 
 build_container: # build container locally
 	$(ENGINE) build -t $(TARGET) -f Dockerfile

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The widget allows users to modify vaccine allocation choices, between- and withi
 ### Run the app locally
 
 1. Enable [poetry](https://python-poetry.org/) with `poetry install`
-2. To run the app: `make`, which calls `streamlit run scripts/app.py`
+2. To run the app: `make` (or `poetry run make`), which calls `streamlit run scripts/app.py`
 3. In a browser, visit: `http://localhost:8501/`
 
 ### Run the app locally using containers


### PR DESCRIPTION
Rather than `make` calling `poetry run streamlit run app.py`, the better pattern is for the user to `poetry run make` and then `make` to simple `streamlit run app.py`.

This allows for situations when the poetry environment is activated and `poetry` may not actually be available.